### PR TITLE
Fixes bug Field Tags bug

### DIFF
--- a/Scripts/fmClip - Wrap Set Field with If-Not-Same.applescript
+++ b/Scripts/fmClip - Wrap Set Field with If-Not-Same.applescript
@@ -21,7 +21,8 @@ property stepSetFieldStart : "<Step enable=\"True\" id=\"76\" name=\"Set Field\"
 property cdataThruTable : "]]></Calculation><Field table=\""
 property tableThruId : "\" id=\""
 property idThruName : "\" name=\""
-property nameThruEndStep : "\"></Field></Step>"
+-- property nameThruEndStep : "\"></Field></Step>"
+property nameThruEndStep : "\">"
 
 property finalXML : "</fmxmlsnippet>"
 


### PR DESCRIPTION
The field name is not always succeeded by "\"></Field>..." This would result in output calculations that include xml tags.

To test, try running the original code on this object:
`<fmxmlsnippet type="FMObjectList">
	<Step enable="True" id="76" name="Set Field">
		<Calculation>
			<![CDATA[$var2]]>
</Calculation>
		<Field table="Parent" id="1" name="id">
			<TagList secondary="True"></TagList>
		</Field>
	</Step>
</fmxmlsnippet>`