### PR TITLE
Fixes backslash bug and debug bug in prettifyXML

### DIFF
--- a/Scripts/fmClip - Wrap Set Field with If-Not-Same.applescript
+++ b/Scripts/fmClip - Wrap Set Field with If-Not-Same.applescript
@@ -21,7 +21,8 @@ property stepSetFieldStart : "<Step enable=\"True\" id=\"76\" name=\"Set Field\"
 property cdataThruTable : "]]></Calculation><Field table=\""
 property tableThruId : "\" id=\""
 property idThruName : "\" name=\""
-property nameThruEndStep : "\"></Field></Step>"
+-- property nameThruEndStep : "\"></Field></Step>"
+property nameThruEndStep : "\">"
 
 property finalXML : "</fmxmlsnippet>"
 

--- a/Scripts/fmObjectTranslator.applescript
+++ b/Scripts/fmObjectTranslator.applescript
@@ -74,15 +74,15 @@ on fmObjectTranslator_Instantiate(prefs)
 		property xmlHeader_LO_current : ""
 		
 		
-		property fmObjCodes : {�
-			{objName:"Step", objCode:"XMSS"}, �
-			{objName:"Layout", objCode:"XML2", secondaryNode:"NOT ObjectStyle"}, �
-			{objName:"Layout", objCode:"XMLO", secondaryNode:"HAS ObjectStyle"}, �
-			{objName:"Group", objCode:"XMSC"}, �
-			{objName:"Script", objCode:"XMSC"}, �
-			{objName:"Field", objCode:"XMFD"}, �
-			{objName:"CustomFunction", objCode:"XMFN"}, �
-			{objName:"BaseTable", objCode:"XMTB"} �
+		property fmObjCodes : { ¬
+			{objName:"Step", objCode:"XMSS"}, ¬
+			{objName:"Layout", objCode:"XML2", secondaryNode:"NOT ObjectStyle"}, ¬
+			{objName:"Layout", objCode:"XMLO", secondaryNode:"HAS ObjectStyle"}, ¬
+			{objName:"Group", objCode:"XMSC"}, ¬
+			{objName:"Script", objCode:"XMSC"}, ¬
+			{objName:"Field", objCode:"XMFD"}, ¬
+			{objName:"CustomFunction", objCode:"XMFN"}, ¬
+			{objName:"BaseTable", objCode:"XMTB"} ¬
 				}
 		
 		property currentCode : ""
@@ -459,7 +459,7 @@ on fmObjectTranslator_Instantiate(prefs)
 			
 			-- 3.7 - 2016-11-02 ( dshockley/eshagdar ): separate test into a variable; renamed variables.
 			-- 3.6 - need to SET currentCode for this object - always.
-			-- 3.5 - no need for file write�to be in tell System Events block
+			-- 3.5 - no need for file write to be in tell System Events block
 			-- converts some string of XML into fmObjects as FM data type
 			
 			if debugMode then logConsole(ScriptName, "convertXmlToObjects: START")
@@ -481,7 +481,7 @@ on fmObjectTranslator_Instantiate(prefs)
 			set xmlFilePath to (POSIX file tempXMLPosix) as string
 			if debugMode then logConsole(ScriptName, "convertXmlToObjects: xmlFilePath: " & xmlFilePath)
 			set xmlHandle to open for access file xmlFilePath with write permission
-			write stringFmXML to xmlHandle as �class utf8�
+			write stringFmXML to xmlHandle as «class utf8»
 			close access xmlHandle
 			set fmObjects to read alias xmlFilePath as fmClass
 			
@@ -585,7 +585,7 @@ on fmObjectTranslator_Instantiate(prefs)
 		
 		
 		on classFromCode(objCode)
-			return run script "�class " & objCode & "�"
+			return run script "«class " & objCode & "»"
 		end classFromCode
 		
 		
@@ -817,7 +817,8 @@ on fmObjectTranslator_Instantiate(prefs)
 						
 					else
 						-- just use echo:
-						set prettyPrint_ShellCommand to "echo " & quoted form of prettyXML & " | " & tidyCommand
+						-- use "shopt -u xpg_echo; echo " instead of "echo" to handle backslashes properly: https://stackoverflow.com/questions/8138167/how-can-i-escape-shell-arguments-in-applescript/8145515
+						set prettyPrint_ShellCommand to "shopt -u xpg_echo; echo " & quoted form of prettyXML & " | " & tidyCommand
 						set prettyXML to do shell script prettyPrint_ShellCommand
 					end if
 					
@@ -934,7 +935,7 @@ on fmObjectTranslator_Instantiate(prefs)
 			if resultType is "utf8" then
 				
 				tell application "System Events"
-					read file tempDataPath as �class utf8�
+					read file tempDataPath as «class utf8»
 				end tell
 				
 				return result
@@ -1153,7 +1154,7 @@ on fmObjectTranslator_Instantiate(prefs)
 			--             while 10.4 uses " into type number.")
 			-- 1.5 -  added Unicode Text
 			
-			set errMsgLeadList to {"Can't make ", "Can�t make "}
+			set errMsgLeadList to {"Can't make ", "Can't make "}
 			set errMsgTrailList to {" into a number.", " into type number."}
 			
 			if class of incomingObject is string then
@@ -1302,7 +1303,7 @@ on fmObjectTranslator_Instantiate(prefs)
 		on recordFromList(assocList)
 			-- version 2003-11-06, Nigel Garvey, AppleScript-Users mailing list
 			try
-				{�class usrf�:assocList}'s x
+				{«class usrf»:assocList}'s x
 			on error msg
 				return msg
 				run script text 16 thru -2 of msg

--- a/Scripts/fmObjectTranslator.applescript
+++ b/Scripts/fmObjectTranslator.applescript
@@ -67,15 +67,15 @@ on fmObjectTranslator_Instantiate(prefs)
 		property xmlHeader_LO_current : ""
 		
 		
-		property fmObjCodes : {Â
-			{objName:"Step", objCode:"XMSS"}, Â
-			{objName:"Layout", objCode:"XML2", secondaryNode:"NOT ObjectStyle"}, Â
-			{objName:"Layout", objCode:"XMLO", secondaryNode:"HAS ObjectStyle"}, Â
-			{objName:"Group", objCode:"XMSC"}, Â
-			{objName:"Script", objCode:"XMSC"}, Â
-			{objName:"Field", objCode:"XMFD"}, Â
-			{objName:"CustomFunction", objCode:"XMFN"}, Â
-			{objName:"BaseTable", objCode:"XMTB"} Â
+		property fmObjCodes : {ï¿½
+			{objName:"Step", objCode:"XMSS"}, ï¿½
+			{objName:"Layout", objCode:"XML2", secondaryNode:"NOT ObjectStyle"}, ï¿½
+			{objName:"Layout", objCode:"XMLO", secondaryNode:"HAS ObjectStyle"}, ï¿½
+			{objName:"Group", objCode:"XMSC"}, ï¿½
+			{objName:"Script", objCode:"XMSC"}, ï¿½
+			{objName:"Field", objCode:"XMFD"}, ï¿½
+			{objName:"CustomFunction", objCode:"XMFN"}, ï¿½
+			{objName:"BaseTable", objCode:"XMTB"} ï¿½
 				}
 		
 		property currentCode : ""
@@ -452,7 +452,7 @@ on fmObjectTranslator_Instantiate(prefs)
 			
 			-- 3.7 - 2016-11-02 ( dshockley/eshagdar ): separate test into a variable; renamed variables.
 			-- 3.6 - need to SET currentCode for this object - always.
-			-- 3.5 - no need for file writeÊto be in tell System Events block
+			-- 3.5 - no need for file writeï¿½to be in tell System Events block
 			-- converts some string of XML into fmObjects as FM data type
 			
 			if debugMode then logConsole(ScriptName, "convertXmlToObjects: START")
@@ -474,7 +474,7 @@ on fmObjectTranslator_Instantiate(prefs)
 			set xmlFilePath to (POSIX file tempXMLPosix) as string
 			if debugMode then logConsole(ScriptName, "convertXmlToObjects: xmlFilePath: " & xmlFilePath)
 			set xmlHandle to open for access file xmlFilePath with write permission
-			write stringFmXML to xmlHandle as Çclass utf8È
+			write stringFmXML to xmlHandle as ï¿½class utf8ï¿½
 			close access xmlHandle
 			set fmObjects to read alias xmlFilePath as fmClass
 			
@@ -578,7 +578,7 @@ on fmObjectTranslator_Instantiate(prefs)
 		
 		
 		on classFromCode(objCode)
-			return run script "Çclass " & objCode & "È"
+			return run script "ï¿½class " & objCode & "ï¿½"
 		end classFromCode
 		
 		
@@ -743,7 +743,8 @@ on fmObjectTranslator_Instantiate(prefs)
 					set someXML to replaceSimple({someXML, tab, tabPlaceholder})
 					
 					set otherTidyOptions to " -i --indent-spaces 4 --literal-attributes yes --drop-empty-paras no --fix-backslash no --fix-bad-comments no --fix-uri no --ncr no --quote-ampersand no --quote-nbsp no "
-					set prettyPrint_ShellCommand to "echo " & quoted form of someXML & " | tidy -xml -m -raw -wrap 999999999999999" & otherTidyOptions
+					-- use "shopt -u xpg_echo; echo " instead of "echo" to handle backslashes properly: https://stackoverflow.com/questions/8138167/how-can-i-escape-shell-arguments-in-applescript/8145515
+					set prettyPrint_ShellCommand to "shopt -u xpg_echo; echo " & quoted form of someXML & " | tidy -xml -m -raw -wrap 999999999999999" & otherTidyOptions
 					-- NOTE: wrapping of lines needs to NEVER occur, so cover petabyte-long lines 
 					
 					set prettyXML to do shell script prettyPrint_ShellCommand
@@ -831,7 +832,7 @@ on fmObjectTranslator_Instantiate(prefs)
 			if resultType is "utf8" then
 				
 				tell application "System Events"
-					read file tempDataPath as Çclass utf8È
+					read file tempDataPath as ï¿½class utf8ï¿½
 				end tell
 				
 				return result
@@ -1050,7 +1051,7 @@ on fmObjectTranslator_Instantiate(prefs)
 			--             while 10.4 uses " into type number.")
 			-- 1.5 -  added Unicode Text
 			
-			set errMsgLeadList to {"Can't make ", "CanÕt make "}
+			set errMsgLeadList to {"Can't make ", "Canï¿½t make "}
 			set errMsgTrailList to {" into a number.", " into type number."}
 			
 			if class of incomingObject is string then
@@ -1165,7 +1166,7 @@ on fmObjectTranslator_Instantiate(prefs)
 		on recordFromList(assocList)
 			-- version 2003-11-06, Nigel Garvey, AppleScript-Users mailing list
 			try
-				{Çclass usrfÈ:assocList}'s x
+				{ï¿½class usrfï¿½:assocList}'s x
 			on error msg
 				return msg
 				run script text 16 thru -2 of msg

--- a/Scripts/fmObjectTranslator.applescript
+++ b/Scripts/fmObjectTranslator.applescript
@@ -11,6 +11,7 @@ on fmObjectTranslator_Instantiate(prefs)
 	script fmObjectTranslator
 		-- version 4.0.4, Daniel A. Shockley
 		
+		-- 4.0.5 - 2019-02-15 ( jwillinghalpern ): preserve backslashes when prettifying xml with shell script.
 		-- 4.0.4 - 2019-01-18 ( eshagdar ): remove EndOfText character ( ascii 3 ).
 		-- 4.0.3 - 2018-12-04 ( dshockley, eshagdar ): remove unneeded whitespace around CDATA inside Calculation tags. 
 		-- 4.0.2 - 2018-10-29 ( dshockley ): prettify used to fail (and just get raw XML) when 'too large'. Use temp file to avoid fail. Bug-fix in dataObjectToUTF8. 
@@ -836,7 +837,6 @@ on fmObjectTranslator_Instantiate(prefs)
 					set stringCalcTagOpen to "<Calculation>"
 					set stringStartCdata to "<![CDATA["
 					
-					if debugMode then my logConsole(ScriptName, "prettifyXML: DEBUG: sample chunk: " & (ASCII number (text 1926 thru 1926 of prettyXML)))
 					
 					repeat with numTabs from 1 to maxTabs
 						set stringBeforeCdata to (stringCalcTagOpen & charCR & repeatString({someString:tab, repeatCount:numTabs}) & stringStartCdata)


### PR DESCRIPTION
Hey! you can ignore the first couple commits as I was just getting in sync with your repo. The real changes here are:
1. fixes the backslash issue I raised earlier. They are now preserved when using prettifyXML. 
2. fixes a problem caused by a 'debug' line that prevented prettification of xml shorter than 1926 characters.